### PR TITLE
Add ReadyKit to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Browse the available boilerplates and starter kits by category:
 - [Enferno Framework](https://enferno.io/) - Flask, open-source
 - [GeniePy](https://geniepy.com/) - FastAPI
 - [PySaaS](https://pysaas.io/) - Python, Pynecone
+- [ReadyKit](https://readykit.dev) - Python, Flask
 
 ### Django
 
@@ -95,7 +96,6 @@ Browse the available boilerplates and starter kits by category:
 - [SaaS Pegasus](https://www.saaspegasus.com/) - Django
 - [Djaodjin](https://djaodjin.com/) - Django, open-source
 - [The SaaS boilerplate by Apptension](https://www.apptension.com/saas-boilerplate) - Django, React
-- [ReadyKit](https://readykit.dev/) - Django
 
 ### Go
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Browse the available boilerplates and starter kits by category:
 - [SaaS Pegasus](https://www.saaspegasus.com/) - Django
 - [Djaodjin](https://djaodjin.com/) - Django, open-source
 - [The SaaS boilerplate by Apptension](https://www.apptension.com/saas-boilerplate) - Django, React
+- [ReadyKit](https://readykit.dev/) - Django
 
 ### Go
 


### PR DESCRIPTION
Added ReadyKit (https://readykit.dev) to the Python section of the SaaS boilerplates list.

ReadyKit is a Flask-based Python SaaS starter kit that provides multi-tenant workspaces, Stripe billing, OAuth auth, and production-ready UI blocks.