### PR TITLE
Add Vibe Coding Starter Kit to Next.js boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Browse the available boilerplates and starter kits by category:
 - [Next Starter AI](https://nextstarter.ai) - Next.js, AI integration
 - [SaasRock](https://saasrock.com) - Next.js
 - [Usenextbase](https://usenextbase.com) - Next.js
+- [Vibe Coding Starter Kit](https://vibecodingstarterkit.io) - Next.js, AI commands, Supabase, Stripe, TypeScript
 - [Robuste](https://robuste.dev) - Ship fast Stay robuste.
 
 ### React


### PR DESCRIPTION
## Adding VCSK to SaaS Boilerplates List

Submitting [Vibe Coding Starter Kit (VCSK)](https://vibecodingstarterkit.io) to the Next.js section.

## About VCSK

- **Focus:** AI-powered Next.js development for non-technical founders
- **Price:** $99 one-time payment (no subscription)
- **Tech Stack:** Next.js 14, Supabase, Stripe, TypeScript, Tailwind CSS
- **Unique Features:**
  - Custom AI commands for rapid development
  - Pre-configured auth, payments, and deployment
  - Built for "vibe coding" workflow
  - Targeted at non-technical founders who want to ship fast

## Why Include VCSK?

- Unique positioning in the SaaS boilerplate space
- AI-first approach differentiates it from traditional boilerplates
- Active product with real landing page and purchase flow
- Fits perfectly in the Next.js category

Thank you for maintaining this comprehensive list!